### PR TITLE
Added Github Workflow to build binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: Release Binaries
+
+on:
+  push:
+    paths:
+      - 'Cargo.toml'
+    branches:
+      - main
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+      should_release: ${{ steps.check-version.outputs.should_release }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      
+      - name: Get current version
+        id: get-version
+        run: |
+          VERSION=$(grep -m1 '^version = ' Cargo.toml | cut -d '"' -f2)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check if version changed
+        id: check-version
+        run: |
+          git fetch origin
+          CHANGED=$(git diff HEAD^ HEAD -- Cargo.toml | grep '^+version = ')
+          if [ ! -z "$CHANGED" ]; then
+            echo "should_release=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_release=false" >> $GITHUB_OUTPUT
+          fi
+
+  build:
+    needs: check-version
+    if: needs.check-version.outputs.should_release == 'true'
+    runs-on: ${{ matrix.os }}
+    
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+            extension: ''
+          - os: windows-latest
+            platform: windows
+            extension: '.exe'
+          - os: macos-latest
+            platform: macos
+            extension: ''
+            
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        
+      - name: Build binary
+        run: cargo build --release
+        
+      - name: Rename binary with version and platform
+        shell: bash
+        run: |
+          cd target/release
+          if [ "${{ matrix.platform }}" = "windows" ]; then
+            mv auto-ytdlp-rs${{ matrix.extension }} auto-ytdlp-${{ needs.check-version.outputs.version }}-${{ matrix.platform }}${{ matrix.extension }}
+          else
+            mv auto-ytdlp-rs auto-ytdlp-${{ needs.check-version.outputs.version }}-${{ matrix.platform }}${{ matrix.extension }}
+          fi
+          
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-${{ matrix.platform }}
+          path: target/release/auto-ytdlp-${{ needs.check-version.outputs.version }}-${{ matrix.platform }}${{ matrix.extension }}
+          
+  create-release:
+    needs: [check-version, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ needs.check-version.outputs.version }}
+          name: Release v${{ needs.check-version.outputs.version }}
+          draft: false
+          prerelease: false
+          files: |
+            binary-*/auto-ytdlp-${{ needs.check-version.outputs.version }}-*

--- a/README.md
+++ b/README.md
@@ -44,19 +44,44 @@ And hey, if you think of some cool feature to add, the code's right there for yo
 
 ## Installation
 
-1. Clone this repository:
+### Using [Pre-built Binaries](https://github.com/panchi64/auto-ytdlp/releases/new)
+
+1. Go to the [Releases page](https://github.com/panchi64/auto-ytdlp/releases/new)
+2. Download the appropriate binary for your system:
+
+   - Windows: `auto-ytdlp-[version]-windows.exe`
+   - macOS: `auto-ytdlp-[version]-macos`
+   - Linux: `auto-ytdlp-[version]-linux`
+
+
+3. Make the binary executable (macOS/Linux only):
+   ```bash
+   chmod +x auto-ytdlp-[version]-[platform]
    ```
+
+4. Optional: Move the binary to a directory in your `PATH`:
+
+   - Windows: Move to `C:\Windows\` or add the binary location to your `PATH`
+   - macOS/Linux:
+      ```bash
+      sudo mv auto-ytdlp-[version]-[platform] /usr/local/bin/auto-ytdlp
+      ```
+
+### Building from source
+
+1. Clone this repository:
+   ```bash
    git clone https://github.com/panchi64/auto-ytdlp.git
    cd auto-ytdlp
    ```
 
 2. Build the project:
-   ```
+   ```bash
    cargo build --release
    ```
 
 3. Run the application:
-   ```
+   ```bash
    cargo run --release
    ```   
 > [!WARNING]
@@ -67,8 +92,12 @@ And hey, if you think of some cool feature to add, the code's right there for yo
 The application can be run in two modes:
 
 ### TUI Mode (Default):
-```
-./auto-ytdlp-rs
+```bash
+# Using pre-built binary
+./auto-ytdlp
+
+# Or if installed to PATH
+auto-ytdlp
 ```
 
 #### Interface Controls
@@ -83,8 +112,12 @@ The application can be run in two modes:
 > All quit options will wait for the currently active downloads to finish, even the **Force Quit**
 
 ### Automated Mode (no TUI):
-```
-./auto-ytdlp-rust --auto
+```bash
+# Using pre-built binary
+./auto-ytdlp --auto
+
+# Or if installed to PATH
+auto-ytdlp --auto
 ```
 
 #### Command Line options
@@ -104,7 +137,7 @@ The application handles several important files:
 
 ## Troubleshooting
 
-1. Ensure yt-dlp is properly installed and in your PATH
+1. Ensure yt-dlp is properly installed and in your `PATH`
 2. Check the logs panel for detailed error messages
 3. Verify your URLs are valid and accessible
 4. Make sure you have write permissions in the download directory


### PR DESCRIPTION
I added a github workflow that builds the binaries for Windows, MacOS and Linux as well as creates a release for them. This only happens if the `Cargo.toml` package version has been updated.