### PR TITLE
Added dependency checks when starting downloads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auto-ytdlp-rs"
-version = "1.0.5"
+version = "1.0.51"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
As the title says, this small update adds a check (when a user tries to start a download) that makes sure the user has `ffmpeg` and `yt-dlp` installed. 

If the script identifies that the user doesn't have either or both of them installed, it shoots out an error message in the log area with a corresponding link directly to the pages where the user can download the dependencies.